### PR TITLE
CODINGPJ-7 code space建立

### DIFF
--- a/static/css/search.css
+++ b/static/css/search.css
@@ -53,10 +53,6 @@ textarea {
     max-height: 120px;
 }
 
-#id_answer { /* 答案框 */
-    min-height: 1000px; /* 明確增加答案框高度 */
-    max-height: 1200px; /* 可選：防止超過某個限制 */
-}
 
 .answer-box {
     overflow-y: auto;
@@ -65,4 +61,7 @@ textarea {
     border-radius: 4px;
     padding: 15px;
     height: 1036px;
+}
+.CodeMirror.cm-s-default {
+    height: 1000px; 
 }

--- a/staticfiles/css/search.css
+++ b/staticfiles/css/search.css
@@ -52,10 +52,6 @@ textarea {
     max-height: 120px;
 }
 
-#id_answer { /* 答案框 */
-    min-height: 1000px; /* 明確增加答案框高度 */
-    max-height: 1200px; /* 可選：防止超過某個限制 */
-}
 
 .answer-box {
     overflow-y: auto;
@@ -64,4 +60,7 @@ textarea {
     border-radius: 4px;
     padding: 15px;
     height: 1036px;
+}
+.CodeMirror.cm-s-default {
+    height: 1000px; 
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,6 +15,13 @@
     </script>
     <link rel="stylesheet" type="text/css" href="{% static 'css/search.css' %}">
     <link rel="icon" type="image/x-icon" href="{% static 'images/favicon.ico' %}">
+    <!-- 引入 CodeMirror 的 CSS -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/codemirror.min.css">
+
+    <!-- 引入 CodeMirror 的語法Highlight、程式碼模式 -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/theme/dracula.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/codemirror.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/mode/python/python.min.js"></script> <!-- 這裡是以 Python 為例 -->
     <title>{% block title %}{% endblock %}</title>
 
     <!-- Additional CSS to push content below fixed navbar -->
@@ -85,6 +92,9 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous">
     </script>
+    <!-- 引入 CodeMirror 的 JavaScript -->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/codemirror.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/mode/python/python.min.js"></script>
 </body>
 
 </html>

--- a/templates/questions/question_create.html
+++ b/templates/questions/question_create.html
@@ -52,7 +52,8 @@
                 <div class="mb-3" style="height: 100%;">
                     <label for="answer" class="form-label">{{ form.answer.label }}</label>
                     <div class="answer-box">
-                        {{ form.answer }}
+                        <!-- 替換原本的 {{ form.answer }} 為 textarea 用於初始化 CodeMirror -->
+                        <textarea id="answer-editor" name="answer">{{ form.answer.value }}</textarea>
                     </div>
                 </div>
             </div>
@@ -67,7 +68,15 @@
         $(document).ready(function() {
             // 取得當前模式（假設模式在後端模板中設置，如 'view' 或 'edit'）
             var mode = "{{ mode }}";  // 這裡假設後端傳遞了一個 'mode' 變數到模板
-
+            // 初始化 CodeMirror 編輯器
+            var editor = CodeMirror.fromTextArea(document.getElementById("answer-editor"), {
+                lineNumbers: true,  // 顯示行號
+                mode: "python",     // 設置程式語言模式，例如 python
+                indentUnit: 4,      // 設置縮排
+                tabSize: 4,         // 設置 tab 鍵大小
+                matchBrackets: true // 高亮顯示括號對
+            });
+    
             // 根據模式初始化表單
             if (mode === 'view') {
                 readonlyMode();
@@ -76,22 +85,26 @@
             }
 
             function readonlyMode() {
+                editor.setOption("readOnly", true);  // 設置 CodeMirror 為只讀模式
                 $('input[name="title"]').prop('readonly', true);
                 $('textarea[name="description"]').prop('readonly', true);
                 $('input[name="answer"]').prop('readonly', true);
                 $('input[name="difficulty"]').prop('readonly', true);
                 // 確保 display_creator 是只讀的，不可修改
                 $('input[name="display_creator"]').prop('readonly', true);
+                $('input, textarea').prop('disabled', true);  // 禁用所有表單欄位
             }
 
             function editMode() {
+                editor.setOption("readOnly", false); // 設置 CodeMirror 為可編輯模式
                 $('input[name="title"]').prop('readonly', false);
                 $('textarea[name="description"]').prop('readonly', false);
                 $('input[name="answer"]').prop('disabled', true);
                 $('input[name="difficulty"]').prop('disabled', true);
                 $('input[name="display_creator"]').prop('disabled', true);
+                $('input, textarea').prop('disabled', false);  // 啟用所有表單欄位
             }
         });
-    </script>    
+    </script>
 </div>
 {% endblock %}

--- a/templates/questions/question_update.html
+++ b/templates/questions/question_update.html
@@ -52,7 +52,7 @@
                 <div class="mb-3">
                     <label for="answer" class="form-label">{{ form.answer.label }}</label>
                     <div class="answer-box">
-                        {{ form.answer }}
+                        <textarea id="answer-editor" name="answer">{{ form.answer.value }}</textarea>
                     </div>
                 </div>
             </div>
@@ -66,33 +66,65 @@
 </div>
 
 <script>
-    document.getElementById('questionForm').onsubmit = function(event) {
-        event.preventDefault();  // 防止默認提交
+    $(document).ready(function() {
+        // 取得當前模式（假設模式在後端模板中設置，如 'view' 或 'edit'）
+        var mode = "{{ mode }}";  // 這裡假設後端傳遞了一個 'mode' 變數到模板
 
-        const formData = new FormData(this);
-        const url = this.action;
-
-        fetch(url, {
-            method: 'POST',
-            body: formData,
-            headers: {
-                'X-Requested-With': 'XMLHttpRequest',  // 確保請求被識別為 Ajax
-            },
-        })
-        .then(response => response.json())
-        .then(data => {
-            if (data.status === 'error') {
-                alert(data.message);  // 顯示錯誤提示
-                console.error(data.form_errors);  // 如果有具體的表單錯誤，可以在控制台檢查具體錯誤信息
-            } else if (data.status === 'success') {
-                alert(data.message);
-                // 根據需求重定向或者刷新頁面
-                window.location.href = '{% url "UserQuestionHistoryList" %}';
-            }
-        })
-        .catch(error => {
-            console.error('Error:', error);
+        // 初始化 CodeMirror 編輯器
+        var editor = CodeMirror.fromTextArea(document.getElementById("answer-editor"), {
+            lineNumbers: true,  // 顯示行號
+            mode: "python",     // 設置程式語言模式，例如 python
+            indentUnit: 4,      // 設置縮排
+            tabSize: 4,         // 設置 tab 鍵大小
+            matchBrackets: true // 高亮顯示括號對
         });
-    };
+
+        // 根據模式初始化表單
+        if (mode === 'view') {
+            readonlyMode();
+        } else {
+            editMode();
+        }
+
+        function readonlyMode() {
+            editor.setOption("readOnly", true);  // 設置 CodeMirror 為只讀模式
+            $('input, textarea').prop('disabled', true);  // 禁用表單欄位
+        }
+
+        function editMode() {
+            editor.setOption("readOnly", false); // 設置 CodeMirror 為可編輯模式
+            $('input, textarea').prop('disabled', false);  // 啟用表單欄位
+        }
+
+        // 提交表單的處理邏輯
+        document.getElementById('questionForm').onsubmit = function(event) {
+            event.preventDefault();  // 防止默認提交
+
+            const formData = new FormData(this);
+            const url = this.action;
+
+            fetch(url, {
+                method: 'POST',
+                body: formData,
+                headers: {
+                    'X-Requested-With': 'XMLHttpRequest',  // 確保請求被識別為 Ajax
+                },
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.status === 'error') {
+                    alert(data.message);  // 顯示錯誤提示
+                    console.error(data.form_errors);  // 如果有具體的表單錯誤，可以在控制台檢查具體錯誤信息
+                } else if (data.status === 'success') {
+                    alert(data.message);
+                    // 根據需求重定向或者刷新頁面
+                    window.location.href = '{% url "UserQuestionHistoryList" %}';
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+            });
+        };
+    });
 </script>
 {% endblock %}


### PR DESCRIPTION
1.新增 CodeMirror 編輯器，將 answer-editor 的 textarea 初始化為支援 Python 語法的程式碼編輯器。 
2.將表單的模式切換（view 或 edit）邏輯與 CodeMirror 編輯器同步，支援唯讀與可編輯模式。 
3.更新 readonlyMode 和 editMode 函數，確保 CodeMirror 編輯器與其他表單欄位狀態一致。 
4.保持原有表單欄位的功能，並根據模式切換動態調整為唯讀或可編輯狀態。